### PR TITLE
Relax Pydantic Version Requirements

### DIFF
--- a/model/playbook_variable_model.py
+++ b/model/playbook_variable_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class PlaybookVariableModel(BaseModel):

--- a/requests_to_curl.py
+++ b/requests_to_curl.py
@@ -5,7 +5,7 @@ import re
 from urllib.parse import urlsplit
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from requests import PreparedRequest  # TYPE-CHECKING
 
 from .util import Util


### PR DESCRIPTION
Pydantic v2 has been around for nearly 2 years, and as such many things use the new version. `tcex` and the associated repositories related to it all have a strict `<2.0.0` requirement on Pydantic, which is problematic when trying to utilize these libraries in a larger application or ecosystem which uses a newer version of Pydantic.

This PR and a collection of others I am in the process of making together aim to relax the version requirements for Pydantic by utilizing the `pydantic.v1` namespace introduced in `v1.10.17`. This `pyandic.v1` namespace allows users to utilize Pydantic as it was in v1 even when v2 is installed. It is explicitly listed as an option in the official [Migration Guide](https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment).

I plan to place this same PR description across all repositories which I found that needed updating, so here's some overarching information about this process as I have been able to understand it:

1. There are three "primary" projects which define Python packages: `tcex`, `tcex-cli`, and `tcex-app-testing`.
2. The primary projects need their `pyproject.toml` updated to relax the requirements to `>=1.10.17,<3.0.0`.
3. Secondary projects are used as submodules within the primary projects. The submodule projects that have references to pydantic are (as far as I could find): `tcex-app-config`, `tcex-app-playbook`, `tcex-util`.
4. All projects (primary and secondary) need all references to importing `pydantic` updated to reference `pydantic.v1`.

This is all relatively straightforward. In the forks I have made, I've run the following straightforward one-liner to replace all `from pydantic...` lines appropriately:

```sh
find . -name '*.py' | while read filepath; do
  sed 's/^from pydantic/from pydantic.v1/g' -i "$filepath"
done
```

For repositories with submodules (the primary repositories mentioned above), I filtered out the submodule paths before making this replacement. After the secondary repositories are merged, the primary repository submodules will also need to be updated to account for these changes in the primary repositories as well.

I will be the first to admit that I am not the best person to test all of this as I'm not intimately familiar with `tcex` or all the in's and out's of your application(s). But I am familiar with Pydantic, and this version conflict is a bump in the road for me, so I'm happy to work through troubleshooting. I'm happy to discuss options and work with the team, but given that this was just a bunch of find-and-replace followed by careful coordination of submodules, I figured I'd at least get the ball rolling.

Once all six of the PRs are open, I'll go back through and make a comment on each to reference the others so they can be properly tracked/linked.